### PR TITLE
Char Filter : Add Ritualist Hunter / Fixed Robot

### DIFF
--- a/js/chara-detail.js
+++ b/js/chara-detail.js
@@ -1044,9 +1044,8 @@
     function getTags(char) {
         return char.tagList.concat(char.position == "MELEE" || char.position == "ALL" ? ["近战位"] : [],    // Melee
                                    char.position == "RANGED" || char.position == "ALL" ? ["远程位"] : [],   // Ranged
-                                   char.rarity == 1 ? ["新手"] : [],                                        // Starter
-                                   char.rarity == 0 ? ["支援机械"] : []);                                    // Robot
-    }
+                                   char.rarity == 1 ? ["新手"] : []                                        // Starter
+    )}
     
     function getBranchClass(char){
         return char.subProfessionId

--- a/json/tl-subclass.json
+++ b/json/tl-subclass.json
@@ -44,7 +44,8 @@
             "closerange",
             "longrange",
             "siegesniper",
-            "bombarder"
+            "bombarder",
+            "hunter"
         ],
         "TANK":[
             "protector",
@@ -61,7 +62,8 @@
             "underminer",
             "bard",
             "blessing",
-            "craftsman"
+            "craftsman",
+            "ritualist"
         ],
         "SPECIAL":[
             "executor",
@@ -128,7 +130,7 @@
         "crusher":{
             "name":"Crusher",
             "tl":"",
-            "en":""
+            "en":"Crusher"
         },
 
         "physician":{
@@ -149,7 +151,7 @@
         "wandermedic":{
             "name":"Wandermedic",
             "tl":"Wandering Medic",
-            "en":""
+            "en":"Wandering Medic"
         },
         "incantationmedic":{
             "name":"Incantation Medic",
@@ -159,7 +161,7 @@
         "chainhealer":{
             "name":"Chain Healer",
             "tl":"Chain Healer",
-            "en":""
+            "en":"Chain Medic"
         },
 
         "agent":{
@@ -259,6 +261,11 @@
             "tl":"Bombardier",
             "en":"Flinger"
         },
+        "hunter":{
+            "name":"Hunter",
+            "tl":"",
+            "en":""
+        },
 
         "protector":{
             "name":"Protector",
@@ -293,7 +300,7 @@
         "shotprotector":{
             "name":"Shot Protector",
             "tl":"Sentinel Iron Guard",
-            "en":""
+            "en":"Sentinel Protector"
         },
 
         "slower":{
@@ -324,6 +331,11 @@
         "craftsman":{
             "name":"Craftsman",
             "tl":"Artificer",
+            "en":"Artificer"
+        },
+        "ritualist":{
+            "name":"Ritualist",
+            "tl":"",
             "en":""
         },
 


### PR DESCRIPTION
## json/tl-subclass.json
Add New Archetype
- Ritualist
- Hunter

Add official EN Archetype name
- Crusher , Wandering Medic , Chain Medic & Sentinel Protector

Note & Issue : 
- No Archetype Image for Ritualist & Hunter in [Arknight-Images](https://github.com/Aceship/Arknight-Images) Repo
- In Jesalter char sheet in CN use archetype name "Sentry Protector" conflict with official EN "Sentinel Protector" (Need follow up)
!["Sentry Protector"](https://media.discordapp.net/attachments/390762720301154305/1148170044216451102/IMG_2263.png?width=1214&height=683)
---
## js/chara-detail.js
Remove force add robot tag from 1* char ![Case in RIHQ](https://media.discordapp.net/attachments/1038241933690163351/1155066318656118815/image.png?width=1287&height=612) [Discord Link](https://discord.com/channels/280709755486470144/580649741906608128/1150015770261200956)